### PR TITLE
Remove --log-level argument for netcup-webhook container in example and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ spec:
         image: ghcr.io/mrueg/external-dns-netcup-webhook:latest
         imagePullPolicy: Always
         args:
-        - --log-level=debug
         - --domain-filter=YOUR_DOMAIN
         - --netcup-customer-id=YOUR_ID
         env:

--- a/example/external-dns.yaml
+++ b/example/external-dns.yaml
@@ -59,7 +59,6 @@ spec:
         image: ghcr.io/mrueg/external-dns-netcup-webhook:latest
         imagePullPolicy: Always
         args:
-        - --log-level=debug
         - --domain-filter=YOUR_DOMAIN
         - --netcup-customer-id=YOUR_ID
         env:


### PR DESCRIPTION
Hello,

Today, I wanted to set up external-dns using the netcup-webhook provider. I used the existing `example/external-dns.yaml` for my setup. Once applied, the deployment was always crashing, with the error message:

```
external-dns-netcup-webhook: error: unknown long flag '--log-level', try --help
```

I don't know if the removal of the `--log-level` argument is/was intended. However, I thought that it would safe others some time (and pain), if we would fix the existing example manifest (and readme) by removing the argument for now.

Kind regards,
Fatih