### PR TITLE
Move health endpoint to metrics server and adjust default network bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,16 +125,6 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
-        readinessProbe:
-          failureThreshold: 6
-          httpGet:
-            path: /healthz
-            port: http-webhook
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.14.0
+        image: registry.k8s.io/external-dns/external-dns:v0.17.0
         args:
         - --log-level=debug
         - --source=ingress
@@ -112,6 +112,29 @@ spec:
             secretKeyRef:
               key: NETCUP_API_PASSWORD
               name: netcup-api-password
+        ports:
+          - containerPort: 8080
+            name: http-webhook
+        livenessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /healthz
+            port: http-webhook
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /healthz
+            port: http-webhook
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
 
 ```
 

--- a/main.go
+++ b/main.go
@@ -166,9 +166,6 @@ func buildWebhookServer(logger *slog.Logger) (*http.ServeMux, error) {
 		Provider: ncProvider,
 	}
 
-	// Inform users of the breaking change of moving the healthz endpoint to the metrics server while the webhook is in major version 0.
-	logger.Warn("The /healthz endpoint has ben moved to the metrics endpoints, please adjust your liveness/readiness probes accordingly")
-
 	// Add negotiatePath
 	mux.HandleFunc(rootPath, p.NegotiateHandler)
 	// Add adjustEndpointsPath

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// The default recommended port for the provider endpoints is 8888, and should listen only on localhost (ie: only accessible for external-dns).
-	listenAddr = kingpin.Flag("listen-address", "The address this plugin listens on").Default("127.0.0.1:8888").Envar("NETCUP_LISTEN_ADDRESS").String()
+	listenAddr = kingpin.Flag("listen-address", "The address this plugin listens on").Default("localhost:8888").Envar("NETCUP_LISTEN_ADDRESS").String()
 	// The default recommended port for the exposed endpoints is 8080, and it should be bound to all interfaces (0.0.0.0)
 	metricsListenAddr = kingpin.Flag("metrics-listen-address", "The address this plugin provides metrics on").Default(":8080").Envar("NETCUP_METRICS_LISTEN_ADDRESS").String()
 	tlsConfig         = kingpin.Flag("tls-config", "Path to TLS config file.").Envar("NETCUP_TLS_CONFIG").Default("").String()


### PR DESCRIPTION
First: thanks for the provider, managing DNS at my favorite provider for _HomeLabs_ via _ExternalDNS_ was a missing feature for a long time 💙

According to [_ExternalDNS_'s webhook provider specification](https://kubernetes-sigs.github.io/external-dns/v0.17.0/docs/tutorials/webhook-provider/#exposed-endpoints) the `/healthz` endpoint is one of the endpoints that should be exposed:

> The default recommended port for the exposed endpoints is `8080`, and it should be bound to all interfaces (`0.0.0.0`).

Currently it is bound to the webhook server itself which [as also documented by the specification](https://kubernetes-sigs.github.io/external-dns/v0.17.0/docs/tutorials/webhook-provider/#provider-endpoints), should not be exposed and bound to `localhost` to be only available for the `external-dns` container (same network namespace):

> The default recommended port for the provider endpoints is `8888`, and should listen only on `localhost` (ie: only accessible for external-dns).

Therefore, this PR…

- moves the endpoint to the webhook server to adhere to the specification (⚠️ breaking change).
- adjusts the address of the webhook server to only bind to `localhost` (using `127.0.0.1` is more portable) to adhere to the specification (⚠️ breaking change).
- adjusts the default port of the metrics server to `8080` to adhere to the specification as well as [the default values of the official ExternalDNS Helm chart](https://github.com/kubernetes-sigs/external-dns/blob/v0.17.0/charts/external-dns/templates/deployment.yaml#L188) (sadly, currently the port is hard-coded) (⚠️ breaking change).
- adds a warning log about this breaking change to allow to adapt since this webhook provider is still in major version 0 which means everything can break at any time.
- extends the example in the _ReadMe_ to show how to use the `/healthz` endpoint which is useful when using the official Helm chart, but need to add the container manually (through the `.extraContainers` attribute).

This change is also a step forward to mitigate problems like https://github.com/kubernetes-sigs/external-dns/issues/5071 which I'm currently facing and decided to submit this PR. The issue is also the not (yet) flexible ExternalDNS Helm chart that makes it not possible to use all webhook providers using the builtin container addition but requires the `.extraContainers` attribute (also had to [submit a PR to fix the type](https://github.com/kubernetes-sigs/external-dns/pull/5564) 🙈) to manually add e.g. this _netcup_ provider without this change.